### PR TITLE
Updating to ssc-testnet-2 chain

### DIFF
--- a/testnets/_IBC/axelartestnet-sagatestnet.json
+++ b/testnets/_IBC/axelartestnet-sagatestnet.json
@@ -2,22 +2,22 @@
   "$schema": "../../ibc_data.schema.json",
   "chain_1": {
     "chain_name": "axelartestnet",
-    "client_id": "07-tendermint-767",
-    "connection_id": "connection-581"
+    "client_id": "07-tendermint-1047",
+    "connection_id": "connection-808"
   },
   "chain_2": {
     "chain_name": "sagatestnet",
-    "client_id": "07-tendermint-11",
-    "connection_id": "connection-10"
+    "client_id": "07-tendermint-2",
+    "connection_id": "connection-3"
   },
   "channels": [
     {
       "chain_1": {
-        "channel_id": "channel-370",
+        "channel_id": "channel-566",
         "port_id": "transfer"
       },
       "chain_2": {
-        "channel_id": "channel-9",
+        "channel_id": "channel-3",
         "port_id": "transfer"
       },
       "ordering": "unordered",

--- a/testnets/sagatestnet/chain.json
+++ b/testnets/sagatestnet/chain.json
@@ -5,7 +5,7 @@
   "network_type": "testnet",
   "pretty_name": "Saga Testnet",
   "chain_type": "cosmos",
-  "chain_id": "ssc-testnet-1",
+  "chain_id": "ssc-testnet-2",
   "bech32_prefix": "saga",
   "daemon_name": "sscd",
   "node_home": "$HOME/.ssc",
@@ -33,12 +33,14 @@
   },
   "codebase": {
     "git_repo": "https://github.com/sagaxyz/ssc",
-    "recommended_version": "v0.1.3",
+    "recommended_version": "v0.1.5",
     "compatible_versions": [
       "v0.1.0",
       "v0.1.1",
       "v0.1.2",
-      "v0.1.3"
+      "v0.1.3",
+      "v0.1.4",
+      "v0.1.5"
     ],
     "consensus": {
       "type": "tendermint",

--- a/testnets/sagatestnet/versions.json
+++ b/testnets/sagatestnet/versions.json
@@ -4,12 +4,14 @@
   "versions": [
     {
       "name": "v0.1.3",
-      "recommended_version": "v0.1.3",
+      "recommended_version": "v0.1.5",
       "compatible_versions": [
         "v0.1.0",
         "v0.1.1",
         "v0.1.2",
-        "v0.1.3"
+        "v0.1.3",
+        "v0.1.4",
+        "v0.1.5"
       ],
       "consensus": {
         "type": "tendermint",


### PR DESCRIPTION
Updating chain config to `ssc-testnet-2` for Cosmos Registry.